### PR TITLE
[FIX] Add force_unlink context value

### DIFF
--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -174,6 +174,9 @@ class StockQuant(models.Model):
             cr, uid, quant.location_id, quant.product_id, quant.qty, dom,
             context=context)
         product_uom_rounding = quant.product_id.uom_id.rounding
+        if context is None:
+            context = {}
+        context.update({'force_unlink': True})
         for quant_neg, qty in quants:
             if not quant_neg or not solving_quant:
                 continue

--- a/stock_quant_cost_segmentation/model/stock.py
+++ b/stock_quant_cost_segmentation/model/stock.py
@@ -174,8 +174,7 @@ class StockQuant(models.Model):
             cr, uid, quant.location_id, quant.product_id, quant.qty, dom,
             context=context)
         product_uom_rounding = quant.product_id.uom_id.rounding
-        if context is None:
-            context = {}
+        context = dict(context or {})
         context.update({'force_unlink': True})
         for quant_neg, qty in quants:
             if not quant_neg or not solving_quant:


### PR DESCRIPTION
In Odoo/odoo commit [4bd64dc](https://github.com/odoo/odoo/commit/4bd64dc91b11726c154a53662b0de91c29b0d718) introduces a validation that avoids user-deletion of quants, So, `force_unlink` context value is _required_ to be taken in count when using unlink(..) method explicitly
